### PR TITLE
[IRIS-7166] IDC의 컴포넌트 활용하여 모달창 퍼블리싱- second correct

### DIFF
--- a/src/html/pages/modal.html
+++ b/src/html/pages/modal.html
@@ -259,7 +259,7 @@
                                     </div>
                                 </div>
                                 <div class="modal__body">
-                                    <div class="modal__body--sm-toggle">
+                                    <div class="modal__body__toggle-container">
                                         <div class="toggle-box">
                                             <span class="toggle-text">공유</span>
                                             <button
@@ -272,7 +272,7 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <div class=" modal__body--sm-link">
+                                    <div class="modal__body__link-container">
                                         <div class="link-box">
                                             <strong class="link-box__title">유기케이스 투기 과열지구</strong>
 
@@ -327,7 +327,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class=" modal__body--sm-help">
+                                    <div class="modal__body__help-container">
                                         <div class="modal__body--sm-help-box">
                                             <svg
                                                 class="modal-help-icon"
@@ -372,7 +372,7 @@
                                     </div>
                                 </div>
                                 <div class="modal__body">
-                                    <div class=" modal__body--sm-toggle">
+                                    <div class="modal__body__toggle-container">
                                         <div class="toggle-box">
                                             <span class="toggle-text">공유</span>
                                             <button
@@ -385,7 +385,7 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <div class=" modal__body--sm-link">
+                                    <div class="modal__body__link-container">
                                         <div class="link-box">
                                             <strong class="link-box__title">유기케이스 투기 과열지구</strong>
 
@@ -405,7 +405,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="modal__body--sm-help">
+                                    <div class="modal__body__help-container">
                                         <div class="modal__body--sm-help-box">
                                             <svg
                                                 class="modal-help-icon"

--- a/src/html/pages/modal.html
+++ b/src/html/pages/modal.html
@@ -155,18 +155,18 @@
                 </div>
                 <div class="container-body">
                     <div class="container-body-box">
-                        <div class="container-body-box__select">
+                        <div class="context-menu">
                             <!--첫번째-->
-                            <div class="select--dashboard">
+                            <div class="context-menu--dashboard">
                                 <button class="button button--link button--lg-dashboard" type="button">
-                                    <svg class="svg-icon select-icon" aria-hidden="true">
+                                    <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                         <use xlink:href="#dashboard-menu"></use>
                                     </svg>
-                                    <span class="select-button__text">대시보드 사용여부</span>
+                                    <span class="context-menu-button__text">대시보드 사용여부</span>
                                 </button>
-                                <div class="select__toggle-box">
+                                <div class="context-menu__toggle-box">
                                     <button
-                                        class="toggle-switch__switch toggle-switch__switch--selected select__toggle-button"
+                                        class="toggle-switch__switch toggle-switch__switch--selected context-menu__toggle-button"
                                         type="button"
                                         aria-selected="true">
                                         <span class="toggle-switch__handle"></span>
@@ -178,28 +178,28 @@
                             </div>
 
                             <button class="button button--link button--lg-common" type="button">
-                                <svg class="svg-icon select-icon" aria-hidden="true">
+                                <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                     <use xlink:href="#template"></use>
                                 </svg>
-                                <span class="select-button__textt">탬플릿으로 등록</span>
+                                <span class="context-menu-button__text">탬플릿으로 등록</span>
                             </button>
                             <button class="button button--link button--lg-common" type="button">
-                                <svg class="svg-icon select-icon" aria-hidden="true">
+                                <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                     <use xlink:href="#key"></use>
                                 </svg>
-                                <span class="select-button__text">권한설정</span>
+                                <span class="context-menu-button__text">권한설정</span>
                             </button>
                             <button class="button button--link button--lg-common" type="button">
-                                <svg class="svg-icon select-icon" aria-hidden="true">
+                                <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                     <use xlink:href="#user-setting"></use>
                                 </svg>
-                                <span class="select-button__text">소유자 설정</span>
+                                <span class="context-menu-button__text">소유자 설정</span>
                             </button>
                             <button class="button button--link button--lg-export" type="button">
                                 <svg style="fill:#005ACD" class="svg-icon export-icon" aria-hidden="true">
                                     <use xlink:href="#url-export"></use>
                                 </svg>
-                                <span class="select-button__text--choise">내보내기 링크</span>
+                                <span class="context-menu-button__text--choise">내보내기 링크</span>
                             </button>
                             <button
                                 class="button button--link button--lg-change"
@@ -220,26 +220,26 @@
                                         d="M17.293 7.793a1 1 0 011.414 0l6.5 6.5a1 1 0 01.255.432l1 3.5a1 1 0 01-.255.982l-4.5 4.5a1 1 0 01-1.414-1.414l4.084-4.084-.767-2.685-6.317-6.317a1 1 0 010-1.414zM4.822 19.765a1 1 0 011.413.057l6 6.5a1 1 0 01-1.47 1.356l-6-6.5a1 1 0 01.057-1.413z"
                                         clip-rule="evenodd"/>
                                 </svg>
-                                <span class="select-button__text">
+                                <span class="context-menu-button__text">
                                     정보 변경</span>
                             </button>
                             <button class="button button--link button--lg-common" type="button">
-                                <svg class="svg-icon select-icon" aria-hidden="true">
+                                <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                     <use xlink:href="#write"></use>
                                 </svg>
-                                <span class="select-button__text">편집</span>
+                                <span class="context-menu-button__text">편집</span>
                             </button>
                             <button class="button button--link button--lg-common" type="button">
-                                <svg class="svg-icon select-icon" aria-hidden="true">
+                                <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                     <use xlink:href="#copy"></use>
                                 </svg>
-                                <span class="select-button__text">복제</span>
+                                <span class="context-menu-button__text">복제</span>
                             </button>
                             <button class="button button--link button--lg-common" type="button">
-                                <svg class="svg-icon select-icon" aria-hidden="true">
+                                <svg class="svg-icon context-menu-icon" aria-hidden="true">
                                     <use xlink:href="#trash"></use>
                                 </svg>
-                                <span class="select-button__text">삭제</span>
+                                <span class="context-menu-button__text">삭제</span>
                             </button>
                         </div>
 
@@ -259,7 +259,7 @@
                                     </div>
                                 </div>
                                 <div class="modal__body">
-                                    <div class="modal__body modal__body--sm-toggle">
+                                    <div class="modal__body--sm-toggle">
                                         <div class="toggle-box">
                                             <span class="toggle-text">공유</span>
                                             <button
@@ -272,18 +272,18 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <div class="modal__body modal__body--sm-link">
+                                    <div class=" modal__body--sm-link">
                                         <div class="link-box">
-                                            <h4 class="link-box__title">유기케이스 투기 과열지구</h4>
+                                            <strong class="link-box__title">유기케이스 투기 과열지구</strong>
 
                                             <div class="link-box__content">
-                                                <div class="link-box__content--teal">
+                                                <div class="link-box__group--teal">
                                                     <div class="badge badge--sm badge--teal">
                                                         <span class="badge__label">기본링크</span>
                                                     </div>
                                                     <a href="#">http://b-iris.mobigen.com/studio/exported/root/유즈케이스</a>
                                                 </div>
-                                                <div class="link-box__content--cyan">
+                                                <div class="link-box__group--cyan">
                                                     <div class="badge badge--sm badge--cyan">
                                                         <span class="badge__label">고정링크</span>
                                                     </div>
@@ -292,16 +292,16 @@
                                             </div>
                                         </div>
                                         <div class="link-box">
-                                            <h4 class="link-box__title">유기케이스 투기 과열지구</h4>
+                                            <strong class="link-box__title">유기케이스 투기 과열지구</strong>
 
                                             <div class="link-box__content">
-                                                <div class="link-box__content--teal">
+                                                <div class="link-box__group--teal">
                                                     <div class="badge badge--sm badge--teal">
                                                         <span class="badge__label">기본링크</span>
                                                     </div>
                                                     <a href="#">http://b-iris.mobigen.com/studio/exported/root/유즈케이스</a>
                                                 </div>
-                                                <div class="link-box__content--cyan">
+                                                <div class="link-box__group--cyan">
                                                     <div class="badge badge--sm badge--cyan">
                                                         <span class="badge__label">고정링크</span>
                                                     </div>
@@ -310,15 +310,15 @@
                                             </div>
                                         </div>
                                         <div class="link-box">
-                                            <h4 class="link-box__title">유기케이스 투기 과열지구</h4>
+                                            <strong class="link-box__title">유기케이스 투기 과열지구</strong>
                                             <div class="link-box__content">
-                                                <div class="link-box__content--teal">
+                                                <div class="link-box__group--teal">
                                                     <div class="badge badge--sm badge--teal">
                                                         <span class="badge__label">기본링크</span>
                                                     </div>
                                                     <a href="#">http://b-iris.mobigen.com/studio/exported/root/유즈케이스</a>
                                                 </div>
-                                                <div class="link-box__content--cyan">
+                                                <div class="link-box__group--cyan">
                                                     <div class="badge badge--sm badge--cyan">
                                                         <span class="badge__label">고정링크</span>
                                                     </div>
@@ -327,7 +327,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="modal__body modal__body--sm-help">
+                                    <div class=" modal__body--sm-help">
                                         <div class="modal__body--sm-help-box">
                                             <svg
                                                 class="modal-help-icon"
@@ -372,7 +372,7 @@
                                     </div>
                                 </div>
                                 <div class="modal__body">
-                                    <div class="modal__body modal__body--sm-toggle">
+                                    <div class=" modal__body--sm-toggle">
                                         <div class="toggle-box">
                                             <span class="toggle-text">공유</span>
                                             <button
@@ -385,18 +385,18 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <div class="modal__body modal__body--sm-link">
+                                    <div class=" modal__body--sm-link">
                                         <div class="link-box">
-                                            <h4 class="link-box__title">유기케이스 투기 과열지구</h4>
+                                            <strong class="link-box__title">유기케이스 투기 과열지구</strong>
 
                                             <div class="link-box__content">
-                                                <div class="link-box__content--teal">
+                                                <div class="link-box__group--teal">
                                                     <div class="badge badge--sm badge--teal">
                                                         <span class="badge__label">기본링크</span>
                                                     </div>
                                                     <a href="#">http://b-iris.mobigen.com/studio/exported/root/유즈케이스</a>
                                                 </div>
-                                                <div class="link-box__content--cyan">
+                                                <div class="link-box__group--cyan">
                                                     <div class="badge badge--sm badge--cyan">
                                                         <span class="badge__label">고정링크</span>
                                                     </div>
@@ -405,7 +405,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="modal__body modal__body--sm-help">
+                                    <div class="modal__body--sm-help">
                                         <div class="modal__body--sm-help-box">
                                             <svg
                                                 class="modal-help-icon"

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -236,7 +236,7 @@ body {
     display: flex;
 }
 
-.container-body-box__select {
+.context-menu {
     position: absolute;
     width: 250px;
     padding: 8px 0;
@@ -258,9 +258,6 @@ body {
     display: block;
 }
 .button--lg-change {
-    
-    
-    text-align: right;
     padding: 4px 0 0 4px;
 }
 
@@ -270,29 +267,29 @@ body {
     display: block;
     text-align: left;
 }
-.select-button__text--choise {
+.context-menu-button__text--choise {
     color: $primary-color;
 }
 
-.select-icon {
+.context-menu-icon {
     width: 20px;
 }
 .change-icon {
     width: 20px;
 }
-.select-button__text {
+.context-menu-button__text {
     font-size: $font-md;
 }
 
-.select--dashboard {
+.context-menu--dashboard {
     display: flex;
     justify-content: space-between;
 }
 
-.select__toggle-box {
+.context-menu__toggle-box {
     @include dash-togglebox;
 }
-.select__toggle-button {
+.context-menu__toggle-button {
     width: 40px;
     height: 20px;
     padding: 1px;
@@ -341,12 +338,8 @@ body {
     padding: $spacing-md 0;
 }
 
-.link-box__content--cyan {
-    @include link-grid;
-}
 
 .modal__body--sm-help {
-
     @include modal-helpbox;
 }
 
@@ -371,14 +364,14 @@ body {
     padding: 0 $spacing-md;
 }
 
-.link-box__content--cyan,
-.link-box__content--teal {
+.link-box__group--cyan,
+.link-box__group--teal {
     margin-bottom: $spacing-sm;
 }
 .badge--teal {
     display: inline-block;
 }
-.link-box__content--cyan {
+.link-box__group--cyan {
     @include link-grid;
 }
 .badge--cyan-link {

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -317,10 +317,10 @@ body {
 .modal__body {
     padding: 0 $spacing-xl;
 }
-.modal__body--sm-toggle {
+.modal__body__toggle-container{
     @include modal-togglebox;
 }
-.modal__body--sm-link {
+.modal__body__link-container{
 
     background-color: $ui-01-color;
     padding: 0 $spacing-md;
@@ -355,14 +355,8 @@ body {
 .modal__body {
     padding: 0 $spacing-xl;
 }
-.modal__body--sm-toggle {
-    @include modal-togglebox;
-}
-.modal__body--sm-link {
 
-    background-color: $ui-01-color;
-    padding: 0 $spacing-md;
-}
+
 
 .link-box__group--cyan,
 .link-box__group--teal {
@@ -378,6 +372,6 @@ body {
     word-break: break-all;
 }
 
-.modal__body--sm-help {
+.modal__body__help-container {
     @include modal-helpbox;
 }


### PR DESCRIPTION
## 구분 ##
[IRIS-7166]

## 수정 내용  ##

`container-body-box__select` -> select 대신 context-menu로 클래스명 수정하였습니다


`link-box__title` 의 h4 태그->  strong 으로 수정했습니다.


`modal__body`자식의 동일한 클래스 ->동일한 클래스를 지우고 .modal__body__toggle-container로 변경했습니다.

`link-box__content--cyan` / `link-box__content--teal`
->link-box__group--cyan/link-box__group--teal로 수정하였습니다.


##  관련 이미지  ## 

## TODO List ##

클래스작명 규칙을 더 명확히 구분하기
더 간단하고 명료하게 짓기..